### PR TITLE
Fixed missing editor

### DIFF
--- a/codemirror.vue
+++ b/codemirror.vue
@@ -46,6 +46,11 @@
       var _this = this
       this.editor = CodeMirror.fromTextArea(this.$el, this.options)
       this.editor.setValue(this.value)
+      // Fixes missing editor. See https://stackoverflow.com/questions/8349571/codemirror-editor-is-not-loading-content-until-clicked
+      setTimeout(function() {
+        _this.editor.refresh()
+      }, 0)
+      
       this.editor.on('change', function(cm) {
         if (_this.skipNextChangeEvent) {
           _this.skipNextChangeEvent = false


### PR DESCRIPTION
In some cases, when editor is just mounted `refresh` must be called according to the author of CodeMirror: https://stackoverflow.com/a/8353537/125351

Otherwise it may end up not visible until first click.